### PR TITLE
feat: Add Declarative Foreign Data Wrapper Management Support Proposal 1

### DIFF
--- a/api/v1/database_types.go
+++ b/api/v1/database_types.go
@@ -173,6 +173,8 @@ type DatabaseSpec struct {
 	// The list of extensions to be managed in the database
 	// +optional
 	Extensions []ExtensionSpec `json:"extensions,omitempty"`
+
+	ForeignDataWrapper []ForeignDataWrapperSpec `json:"fdws,omitempty"`
 }
 
 // DatabaseObjectSpec contains the fields which are common to every
@@ -220,6 +222,22 @@ type ExtensionSpec struct {
 	Schema string `json:"schema,omitempty"`
 }
 
+type ForeignDataWrapperSpec struct {
+	// Common fields
+	DatabaseObjectSpec `json:",inline"`
+
+	Handler            string                        `json:"handler,omitempty"`
+	Validator          string                        `json:"validator,omitempty"`
+	Options            map[string]string             `json:"options,omitempty"`
+	Owner              string                        `json:"owner,omitempty"`
+	RequiredExtensions []string                      `json:"requires,omitempty"`
+	Privileges         []ForeignDataWrapperPrivilege `json:"privileges,omitempty"`
+}
+
+type ForeignDataWrapperPrivilege struct {
+	Role string `json:"role"`
+}
+
 // DatabaseStatus defines the observed state of Database
 type DatabaseStatus struct {
 	// A sequence number representing the latest
@@ -242,6 +260,8 @@ type DatabaseStatus struct {
 	// Extensions is the status of the managed extensions
 	// +optional
 	Extensions []DatabaseObjectStatus `json:"extensions,omitempty"`
+
+	ForeignDataWrappers []DatabaseObjectStatus `json:"fdws,omitempty"`
 }
 
 // DatabaseObjectStatus is the status of the managed database objects

--- a/internal/management/controller/database_controller.go
+++ b/internal/management/controller/database_controller.go
@@ -67,6 +67,13 @@ var extensionObjectManager = databaseObjectManager[apiv1.ExtensionSpec, extInfo]
 	drop:   dropDatabaseExtension,
 }
 
+var fdwObjectManager = databaseObjectManager[apiv1.ForeignDataWrapperSpec, fdwInfo]{
+	get:    getDatabaseForeignDataWrapperInfo,
+	create: createDatabaseForeignDataWrapper,
+	update: updateDatabaseForeignDataWrapper,
+	drop:   dropDatabaseForeignDataWrapper,
+}
+
 // databaseReconciliationInterval is the time between the
 // database reconciliation loop failures
 const databaseReconciliationInterval = 30 * time.Second
@@ -262,6 +269,7 @@ func (r *DatabaseReconciler) reconcileDatabaseObjects(
 
 	obj.Status.Schemas = schemaObjectManager.reconcileList(ctx, db, obj.Spec.Schemas)
 	obj.Status.Extensions = extensionObjectManager.reconcileList(ctx, db, obj.Spec.Extensions)
+	obj.Status.ForeignDataWrappers = fdwObjectManager.reconcileList(ctx, db, obj.Spec.ForeignDataWrapper)
 	return nil
 }
 

--- a/internal/management/controller/database_controller_sql.go
+++ b/internal/management/controller/database_controller_sql.go
@@ -43,6 +43,19 @@ type schemaInfo struct {
 	Owner string `json:"owner"`
 }
 
+type fdwInfo struct {
+	extInfo    `json:"extInfo"`
+	Handler    string            `json:"handler,omitempty"`
+	Validator  string            `json:"validator,omitempty"`
+	Options    map[string]string `json:"options,omitempty"`
+	Owner      string            `json:"owner,omitempty"`
+	Privileges []fdwPrivilege    `json:"privileges,omitempty"`
+}
+
+type fdwPrivilege struct {
+	Role string `json:"role"`
+}
+
 func detectDatabase(
 	ctx context.Context,
 	db *sql.DB,
@@ -276,6 +289,8 @@ func createDatabaseExtension(ctx context.Context, db *sql.DB, ext apiv1.Extensio
 	}
 	contextLogger.Info("created extension", "name", ext.Name)
 
+	// run extension create from extensions/extension.go
+
 	return nil
 }
 
@@ -324,6 +339,41 @@ func updateDatabaseExtension(ctx context.Context, db *sql.DB, spec apiv1.Extensi
 		contextLogger.Info("altered extension version", "name", spec.Name, "version", spec.Version)
 	}
 
+	return nil
+}
+
+// support postgres_fdw
+func getDatabaseForeignDataWrapperInfo(ctx context.Context, db *sql.DB, spec apiv1.ForeignDataWrapperSpec) (*fdwInfo, error) {
+	// TODO: implement this function
+	// 1. check if the foreign data wrapper exists
+	// 2. if it does not exist, return nil
+	// 3. if it exists, get and return the info
+	return nil, nil
+}
+
+func createDatabaseForeignDataWrapper(ctx context.Context, db *sql.DB, spec apiv1.ForeignDataWrapperSpec) error {
+	// TODO: implement this function
+	// https://www.postgresql.org/docs/current/sql-alterforeigndatawrapper.html
+	// prerequisite: check if the RequiredExtensions exists, if not create it or return an error (TBD)
+	// 1. run CREATE FOREIGN DATA WRAPPER
+	// 2. error handling
+	// 3. Grant privileges
+	return nil
+}
+
+func dropDatabaseForeignDataWrapper(ctx context.Context, db *sql.DB, spec apiv1.ForeignDataWrapperSpec) error {
+	// TODO: implement this function
+	// https://www.postgresql.org/docs/current/sql-dropforeigndatawrapper.html
+	// 1. run DROP FOREIGN DATA WRAPPER [ IF EXISTS ] name [, ...] [ CASCADE | RESTRICT ]
+	// 2. error handling
+	return nil
+}
+
+func updateDatabaseForeignDataWrapper(ctx context.Context, db *sql.DB, spec apiv1.ForeignDataWrapperSpec, info *fdwInfo) error {
+	// TODO: implement this function
+	// https://www.postgresql.org/docs/current/sql-alterforeigndatawrapper.html
+	// 1. run ALTER FOREIGN DATA WRAPPER name
+	// 2. error handling
 	return nil
 }
 


### PR DESCRIPTION
# feat: Add Declarative Foreign Data Wrapper Management Support

## Description

After going through the issue: https://github.com/cloudnative-pg/cloudnative-pg/issues/6292 and PR: https://github.com/cloudnative-pg/cloudnative-pg/pull/7062, they seem to be a perfect example to implement Foreign Data Wrappers (FDWs) in the CloudNativePG.

So I drafted this PR according to https://github.com/cloudnative-pg/cloudnative-pg/pull/7062 to be part of my proposal.

## Key Implementation
- Introduced `ForeignDataWrapperSpec` and `ForeignDataWrapperPrivilege` to the `DatabaseSpec` struct.
- Integrated FDW lifecycle management (`get`, `create`, `update`, `drop`) into the `database_controller.go` using a generic `databaseObjectManager`.

## Example YAML
```yaml
spec:
  fdws:
    - name: my_fdw
      handler: my_fdw_handler
      validator: my_fdw_validator
      options:
        key: value
      owner: postgres
      requires:
        - extension_name
      privileges:
        - role: readonly
```

## Follow-up Work

- [ ] Add example to config/crd/bases
- [ ] Add documentation for FDW support
- [ ] Add release note entry
- [ ] Add end-to-end (E2E) test for FDW reconciliation